### PR TITLE
Added signs for items (in inventory) for not given/eaten items and counter for already eaten/all eaten and already sold/all sold

### DIFF
--- a/zFoods_TCoM/Dishes.cpp
+++ b/zFoods_TCoM/Dishes.cpp
@@ -1,0 +1,129 @@
+// Supported with union (c) 2020 Union team
+// Union SOURCE file
+
+namespace GOTHIC_ENGINE {
+	Dishes::Dishes() {
+	}
+
+	Dishes::MyMap Dishes::Data = {
+	{"ITFO_PICKLEDBEET", {"meal_pickledbeet_checkbonus", "nob_checkmeal_pickledbeet", "mealname_pickledbeet", true}},
+	{"ITFO_BEERBREAD", {"meal_beerbread_checkbonus", "nob_checkmeal_beerbread", "mealname_beerbread", true}},
+	{"ITFO_PUMPKINCOMPOTE", {"meal_pumpkincompote_checkbonus", "nob_checkmeal_pumpkincompote", "mealname_pumpkincompote", true}},
+	{"ITFO_HONEYCOOKIES", {"meal_honeycookies_checkbonus", "nob_checkmeal_honeycookies", "mealname_honeycookies", true}},
+	{"ITFO_FRIEDFISHSKINS", {"meal_friedfishskins_checkbonus", "nob_checkmeal_friedfishskins", "mealname_friedfishskins", true}},
+	{"ITFO_SCAVENGERSHASHLIK", {"meal_scavengershashlik_checkbonus", "nob_checkmeal_scavengershashlik", "mealname_scavengershashlik", true}},
+	{"ITFO_ROASTEDINSECTS", {"meal_roastedinsects_checkbonus", "nob_checkmeal_roastedinsects", "mealname_roastedinsects", true}},
+	{"ITFO_CABBAGESOUP", {"meal_cabbagesoup_checkbonus", "nob_checkmeal_cabbagesoup", "mealname_cabbagesoup", true}},
+	{"ITFO_MUSHROOMCOTLET", {"meal_mushroomcotlet_checkbonus", "nob_checkmeal_mushroomcotlet", "mealname_mushroomcotlet", true}},
+	{"ITFO_DRYFRUITCOMPOTE", {"meal_dryfruitcompote_checkbonus", "nob_checkmeal_dryfruitcompote", "mealname_dryfruitcompote", true}},
+	{"ITFO_FISHVINEGAR", {"meal_fishvinegar_checkbonus", "nob_checkmeal_fishvinegar", "mealname_fishvinegar", true}},
+	{"ITFO_MANAPERMSOUP", {"meal_manapermsoup_checkbonus", "nob_checkmeal_manapermsoup", "mealname_manapermsoup", false}},
+	{"ITFO_SWEETBUN", {"meal_sweetbun_checkbonus", "nob_checkmeal_sweetbun", "mealname_sweetbun", true}},
+	{"ITFO_MUSHROOMSOUP", {"meal_mushroomsoup_checkbonus", "nob_checkmeal_mushroomsoup", "mealname_mushroomsoup", true}},
+	{"ITFO_RIVERMIRTSOUP", {"meal_rivermirtsoup_checkbonus", "nob_checkmeal_rivermirtsoup", "mealname_rivermirtsoup", true}},
+	{"ITFO_SPEEDHERBOYSTERS", {"meal_speedherboysters_checkbonus", "nob_checkmeal_speedherboysters", "mealname_speedherboysters", true}},
+	{"ITFO_BOARSTEW", {"meal_boarstew_checkbonus", "nob_checkmeal_boarstew", "mealname_boarstew", true}},
+	{"ITFO_MEATMISHMASH", {"meal_meatmishmash_checkbonus", "nob_checkmeal_meatmishmash", "mealname_meatmishmash", true}},
+	{"ITFO_RATSTICK", {"meal_ratstick_checkbonus", "nob_checkmeal_ratstick", "mealname_ratstick", true}},
+	{"ITFO_MULLEDWISP", {"meal_mulledwisp_checkbonus", "nob_checkmeal_mulledwisp", "mealname_mulledwisp", true}},
+	{"ITFO_FISHCOTLET", {"meal_fishcotlet_checkbonus", "nob_checkmeal_fishcotlet", "mealname_fishcotlet", true}},
+	{"ITFO_FISHFILLETPERM", {"meal_fishfilletperm_checkbonus", "nob_checkmeal_fishfilletperm", "mealname_fishfilletperm", false}},
+	{"ITFO_POORBROTH", {"meal_poorbroth_checkbonus", "nob_checkmeal_poorbroth", "mealname_poorbroth", true}},
+	{"ITFO_HERBSTEW", {"meal_herbstew_checkbonus", "nob_checkmeal_herbstew", "mealname_herbstew", true}},
+	{"ITFO_MEATANDCHEESE", {"meal_meatandcheese_checkbonus", "nob_checkmeal_meatandcheese", "mealname_meatandcheese", true}},
+	{"ITFO_MEATANDBREAD", {"meal_meatandbread_checkbonus", "nob_checkmeal_meatandbread", "mealname_meatandbread", true}},
+	{"ITFO_MUSHROOMSTEW", {"meal_mushroomstew_checkbonus", "nob_checkmeal_mushroomstew", "mealname_mushroomstew", true}},
+	{"ITFO_POORAPPLEPIE", {"meal_poorapplepie_checkbonus", "nob_checkmeal_poorapplepie", "mealname_poorapplepie", true}},
+	{"ITFO_POORPATE", {"meal_poorpate_checkbonus", "nob_checkmeal_poorpate", "mealname_poorpate", true}},
+	{"ITFO_PICKLEDMUSHROOMS", {"meal_pickledmushrooms_checkbonus", "nob_checkmeal_pickledmushrooms", "mealname_pickledmushrooms", true}},
+	{"ITFO_BREADSOUP", {"meal_breadsoup_checkbonus", "nob_checkmeal_breadsoup", "mealname_breadsoup", true}},
+	{"ITFO_SHEPARDROAST", {"meal_shepardroast_checkbonus", "nob_checkmeal_shepardroast", "mealname_shepardroast", true}},
+	{"ITFO_POOREGGS", {"meal_pooreggs_checkbonus", "nob_checkmeal_pooreggs", "mealname_pooreggs", true}},
+	{"ITFO_BEERFISH", {"meal_beerfish_checkbonus", "nob_checkmeal_beerfish", "mealname_beerfish", true}},
+	{"ITFO_SPICYPIE", {"meal_spicypie_checkbonus", "nob_checkmeal_spicypie", "mealname_spicypie", true}},
+	{"ITFO_VEGEPIE", {"meal_vegepie_checkbonus", "nob_checkmeal_vegepie", "mealname_vegepie", true}},
+	{"ITFO_FATSTEW", {"meal_fatstew_checkbonus", "nob_checkmeal_fatstew", "mealname_fatstew", true}},
+	{"ITFO_BEARSTEW", {"meal_bearstew_checkbonus", "nob_checkmeal_bearstew", "mealname_bearstew", true}},
+	{"ITFO_HUNTERSPECIAL", {"meal_hunterspecial_checkbonus", "nob_checkmeal_hunterspecial", "mealname_hunterspecial", true}},
+	{"ITFO_SPEEDSTEW", {"meal_speedstew_checkbonus", "nob_checkmeal_speedstew", "mealname_speedstew", true}},
+	{"ITFO_SMOKEDHERBFISH", {"meal_smokedherbfish_checkbonus", "nob_checkmeal_smokedherbfish", "mealname_smokedherbfish", true}},
+	{"ITFO_MEATPACKS", {"meal_meatpacks_checkbonus", "nob_checkmeal_meatpacks", "mealname_meatpacks", true}},
+	{"ITFO_HERBMUSHROOMBREWING", {"meal_herbmushroombrewing_checkbonus", "nob_checkmeal_herbmushroombrewing", "mealname_herbmushroombrewing", true}},
+	{"ITFO_BERRYJAM", {"meal_berryjam_checkbonus", "nob_checkmeal_berryjam", "mealname_berryjam", true}},
+	{"ITFO_STRENGTHJAM", {"meal_strengthjam_checkbonus", "nob_checkmeal_strengthjam", "mealname_strengthjam", false}},
+	{"ITFO_DEXDUMPLINGS", {"meal_dexdumplings_checkbonus", "nob_checkmeal_dexdumplings", "mealname_dexdumplings", false}},
+	{"ITFO_SIMPLEOYSTERS", {"meal_simpleoysters_checkbonus", "nob_checkmeal_simpleoysters", "mealname_simpleoysters", true}},
+	{"ITFO_BERRYCOMPOTE", {"meal_berrycompote_checkbonus", "nob_checkmeal_berrycompote", "mealname_berrycompote", true}},
+	{"ITFO_RASPBERRYDRINK", {"meal_raspberrydrink_checkbonus", "nob_checkmeal_raspberrydrink", "mealname_raspberrydrink", true}},
+	{"ITFO_GRAPEJUICE", {"meal_grapejuice_checkbonus", "nob_checkmeal_grapejuice", "mealname_grapejuice", true}},
+	{"ITFO_RASPBERRYTINCTURE", {"meal_raspberrytincture_checkbonus", "nob_checkmeal_raspberrytincture", "mealname_raspberrytincture", true}},
+	{"ITFO_EXOTICDESSERT", {"meal_exoticdessert_checkbonus", "nob_checkmeal_exoticdessert", "mealname_exoticdessert", true}},
+	{"ITFO_APPLEPIE", {"meal_applepie_checkbonus", "nob_checkmeal_applepie", "mealname_applepie", true}},
+	{"ITFO_SPICYFISH", {"meal_spicyfish_checkbonus", "nob_checkmeal_spicyfish", "mealname_spicyfish", true}},
+	{"ITFO_HERBFISHSOUP", {"meal_herbfishsoup_checkbonus", "nob_checkmeal_herbfishsoup", "mealname_herbfishsoup", true}},
+	{"ITFO_TROLLSOUP", {"meal_trollsoup_checkbonus", "nob_checkmeal_trollsoup", "mealname_trollsoup", false}},
+	{"ITFO_WEEDSTEW", {"meal_weedstew_checkbonus", "nob_checkmeal_weedstew", "mealname_weedstew", true}},
+	{"ITFO_FISHPOT", {"meal_fishpot_checkbonus", "nob_checkmeal_fishpot", "mealname_fishpot", true}},
+	{"ITFO_BATSTEW", {"meal_batstew_checkbonus", "-", "foodname_batstew", false}},
+	{"ITFO_REDSTEW", {"meal_redstew_checkbonus", "-", "foodname_redstew", false}},
+	{"ITFO_BLUESTEW", {"meal_bluestew_checkbonus", "-", "foodname_bluestew", false}},
+	{"ITFO_SLAGERMEAT", {"meal_slagermeat_checkbonus", "-", "foodname_slagermeat", false}},
+	{"ITFO_MARTHSOUP", {"meal_marthsoup1_checkbonus", "-", "itemname_itfo_marthsoup", false}},
+	{"ITFO_MARTHSOUP2", {"meal_marthsoup2_checkbonus", "-", "itemname_itfo_marthsoup2", false}},
+	{"ITFO_MARTHSOUP3", {"meal_marthsoup3_checkbonus", "nob_checkmeal_marthastew", "mealname_marthastew", true}},
+	{"ITFO_MARTHSOUP4", {"meal_marthsoup4_checkbonus", "nob_checkmeal_marthastew_str", "mealname_marthastew_str", true}}
+	};
+
+	int Dishes::allDishesCount = static_cast<int>(Dishes::Data.size());
+	int Dishes::allGivableDishesCount = Dishes::CountGivableDishes();
+
+	int Dishes::CountGivableDishes() {
+		int count = 0;
+		for (auto it = Dishes::Data.begin(); it != Dishes::Data.end(); it++)
+		{
+			if (it->second.jilCanBuy)
+				count++;
+		}
+
+		return count;
+	}
+
+	int Dishes::GetAllDishesCount() {
+		return Dishes::allDishesCount;
+	}
+
+	int Dishes::GetAllGivableCount() {
+		return Dishes::allGivableDishesCount;
+	}
+
+	int Dishes::GetCurrentEatenDishesCount() {
+		int count = 0;
+		for (auto it = Dishes::Data.begin(); it != Dishes::Data.end(); it++)
+		{
+			if (GetValueInt(it->second.eaten) > 0)
+				count++;
+		}
+
+		return count;
+	}
+
+	int Dishes::GetCurrentGivenDishesCount() {
+		int count = 0;
+		for (auto it = Dishes::Data.begin(); it != Dishes::Data.end(); it++)
+		{
+			if (it->second.jilCanBuy && GetValueInt(it->second.jil) > 0)
+				count++;
+		}
+
+		return count;
+	}
+
+	TCoMDishVars* Dishes::Find(const string& key) {
+		auto it = Dishes::Data.find(key);
+		if (it != Dishes::Data.end()) {
+			return &it->second;
+		}
+
+		return nullptr;
+	}
+}

--- a/zFoods_TCoM/Dishes.h
+++ b/zFoods_TCoM/Dishes.h
@@ -1,0 +1,30 @@
+// Supported with union (c) 2020 Union team
+// Union HEADER file
+
+#include <map>
+
+namespace GOTHIC_ENGINE {
+	struct TCoMDishVars {
+		string eaten;
+		string jil;
+		string name;
+		bool jilCanBuy;
+	};
+
+	static class Dishes {
+		Dishes();
+		typedef std::map<string, TCoMDishVars, std::less<string>> MyMap;
+		static int allDishesCount;
+		static int allGivableDishesCount;
+		static int CountGivableDishes();
+
+
+	public:
+		static int GetAllDishesCount();
+		static int GetAllGivableCount();
+		static int GetCurrentEatenDishesCount();
+		static int GetCurrentGivenDishesCount();
+		static TCoMDishVars* Find(const string& key);
+		static MyMap Data;
+	};
+}

--- a/zFoods_TCoM/Headers.h
+++ b/zFoods_TCoM/Headers.h
@@ -4,6 +4,7 @@
 // Automatically generated block
 #pragma region Includes
 #include "Plugin.h"
+#include "Dishes.h"
 #pragma endregion
 
 // ...

--- a/zFoods_TCoM/Plugin.cpp
+++ b/zFoods_TCoM/Plugin.cpp
@@ -27,6 +27,42 @@ namespace GOTHIC_ENGINE {
 		return val;
 	}
 
+	void DrawLetter(oCItem* renderedItem, zCViewBase* viewBase) {
+		zCView* itemView = dynamic_cast<zCView*>(viewBase);
+		if (!itemView)
+			return;
+
+		if ((renderedItem->HasFlag(ITM_CAT_FOOD))) {
+			TCoMDishVars* dish = Dishes::Find(renderedItem->GetObjectName());
+			if (!dish)
+				return;
+
+			if (dish->jilCanBuy && !GetValueInt(dish->jil)) {
+				auto letter = new zCView(6500, 5000, 8000, 7000);
+				letter->SetFontColor(zCOLOR(255, 140, 0));
+				letter->Print(0, 0, "J");
+				itemView->InsertItem(letter);
+				letter->Blit();
+				delete letter;
+			}
+
+			if (!GetValueInt(dish->eaten)) {
+				auto letter = new zCView(6500, 900, 8000, 2900);
+				letter->SetFontColor(zCOLOR(241, 196, 15));
+				letter->Print(0, 0, "B");
+				itemView->InsertItem(letter);
+				letter->Blit();
+				delete letter;
+			}
+		}
+	}
+
+	HOOK Hook_oCItem_RenderItem PATCH(&oCItem::RenderItem, &oCItem::RenderItem_Union);
+	void oCItem::RenderItem_Union(zCWorld* wld, zCViewBase* view, float rotate) {
+		DrawLetter(this, view);
+		THISCALL(Hook_oCItem_RenderItem)(wld, view, rotate);
+	}
+
 	void OpenMenu() {
 		TSystemLangID lang = Union.GetSystemLanguage();
 		bInMenu = true;

--- a/zFoods_TCoM/Plugin.cpp
+++ b/zFoods_TCoM/Plugin.cpp
@@ -50,9 +50,14 @@ namespace GOTHIC_ENGINE {
 		int xJil = 45;
 		int xEaten = 52;
 
+		string sEatenInfo = Z Dishes::GetCurrentEatenDishesCount() + "/" + Z Dishes::GetAllDishesCount();
+		string sGivenInfo = Z Dishes::GetCurrentGivenDishesCount() + "/" + Z Dishes::GetAllGivableCount();
+
 		screenFoods->Print(F(xName), F(y), lang == Lang_Pol ? "Nazwa" : "Name");
 		screenFoods->Print(F(xJil), F(y), GetValueString("npcname_jil"));
+		screenFoods->Print(F(xJil), (F(y)) - 200, sGivenInfo);
 		screenFoods->Print(F(xEaten), F(y), lang == Lang_Pol ? "Zjedzone" : "Eaten");
+		screenFoods->Print(F(xEaten), (F(y)) - 200, sEatenInfo);
 		zSTRING sCode = lang == Lang_Pol ? "Kod" : "Code";
 		screenFoods->Print(8192 - screenFoods->FontSize(sCode) - F(xMargin), F(y), sCode);
 

--- a/zFoods_TCoM/Plugin.cpp
+++ b/zFoods_TCoM/Plugin.cpp
@@ -53,59 +53,23 @@ namespace GOTHIC_ENGINE {
 		screenFoods->Print(F(xName), F(y), lang == Lang_Pol ? "Nazwa" : "Name");
 		screenFoods->Print(F(xJil), F(y), GetValueString("npcname_jil"));
 		screenFoods->Print(F(xEaten), F(y), lang == Lang_Pol ? "Zjedzone" : "Eaten");
-		zSTRING sCode = lang == Lang_Pol ? "Kod (dodaj itfo_)" : "Code (add itfo_)";
+		zSTRING sCode = lang == Lang_Pol ? "Kod" : "Code";
 		screenFoods->Print(8192 - screenFoods->FontSize(sCode) - F(xMargin), F(y), sCode);
 
 		zSTRING sYes = lang == Lang_Pol ? "Tak" : "Yes";
 		zSTRING sNo = lang == Lang_Pol ? "Nie" : "No";
 
-		for (std::map<string, bool_t>::iterator it = Foods.begin(); it != Foods.end(); it++) {
+		for (auto it = Dishes::Data.begin(); it != Dishes::Data.end(); it++) {
 			if (i >= start && i < end) {
 				y = base + (count * 3);
 				zSTRING foodName = "-";
 				zSTRING foodGiven = "-";
 				zSTRING foodEaten = "-";
-				if (it->second) {
-					foodName = GetValueString("mealname_" + it->first);
-					foodGiven = GetValueInt("nob_checkmeal_" + it->first) == 1 ? sYes : sNo;
-					foodEaten = GetValueInt("meal_" + it->first + "_checkbonus") == 1 ? sYes : sNo;
-				}
-				else {
-					if (it->first == "batstew") {
-						foodName = GetValueString("foodname_batstew");
-						foodEaten = GetValueInt("meal_" + it->first + "_checkbonus") == 1 ? sYes : sNo;
-					}
-					else if (it->first == "redstew") {
-						foodName = GetValueString("foodname_redstew");
-						foodEaten = GetValueInt("meal_" + it->first + "_checkbonus") == 1 ? sYes : sNo;
-					}
-					else if (it->first == "bluestew") {
-						foodName = GetValueString("foodname_bluestew");
-						foodEaten = GetValueInt("meal_" + it->first + "_checkbonus") == 1 ? sYes : sNo;
-					}
-					else if (it->first == "slagermeat") {
-						foodName = GetValueString("foodname_slagermeat");
-						foodEaten = GetValueInt("meal_" + it->first + "_checkbonus") == 1 ? sYes : sNo;
-					}
-					else if (it->first == "marthsoup") {
-						foodName = GetValueString("itemname_itfo_marthsoup");
-						foodEaten = GetValueInt("meal_marthsoup1_checkbonus") == 1 ? sYes : sNo;
-					}
-					else if (it->first == "marthsoup2") {
-						foodName = GetValueString("itemname_itfo_marthsoup2");
-						foodEaten = GetValueInt("meal_" + it->first + "_checkbonus") == 1 ? sYes : sNo;
-					}
-					else if (it->first == "marthsoup3") {
-						foodName = GetValueString("mealname_marthastew");
-						foodGiven = GetValueInt("nob_checkmeal_marthastew") == 1 ? sYes : sNo;
-						foodEaten = GetValueInt("meal_" + it->first + "_checkbonus") == 1 ? sYes : sNo;
-					}
-					else if (it->first == "marthsoup4") {
-						foodName = GetValueString("mealname_marthastew_str");
-						foodGiven = GetValueInt("nob_checkmeal_marthastew_str") == 1 ? sYes : sNo;
-						foodEaten = GetValueInt("meal_" + it->first + "_checkbonus") == 1 ? sYes : sNo;
-					}
-				}
+
+				foodName = GetValueString(it->second.name);
+				foodEaten = GetValueInt(it->second.eaten) == 1 ? sYes : sNo;
+				if (it->second.jilCanBuy)
+					foodGiven = GetValueInt(it->second.jil) == 1 ? sYes : sNo;
 
 				int foodNameSize = screenFoods->FontSize(foodName);
 				int letterSize = foodNameSize / foodName.Length();
@@ -163,74 +127,6 @@ namespace GOTHIC_ENGINE {
 			screenFoods->SetPos(F((100 - SizeX) / 2), F((100 - SizeY) / 2));
 			screenFoods->InsertBack("SCROLL_ELEGANT_01.tga");
 		}
-
-		Foods["pickledbeet"] = true;
-		Foods["beerbread"] = true;
-		Foods["pumpkincompote"] = true;
-		Foods["honeycookies"] = true;
-		Foods["friedfishskins"] = true;
-		Foods["scavengershashlik"] = true;
-		Foods["roastedinsects"] = true;
-		Foods["cabbagesoup"] = true;
-		Foods["mushroomcotlet"] = true;
-		Foods["dryfruitcompote"] = true;
-		Foods["fishvinegar"] = true;
-		Foods["manapermsoup"] = true;
-		Foods["sweetbun"] = true;
-		Foods["mushroomsoup"] = true;
-		Foods["rivermirtsoup"] = true;
-		Foods["speedherboysters"] = true;
-		Foods["boarstew"] = true;
-		Foods["meatmishmash"] = true;
-		Foods["ratstick"] = true;
-		Foods["mulledwisp"] = true;
-		Foods["fishcotlet"] = true;
-		Foods["fishfilletperm"] = true;
-		Foods["poorbroth"] = true;
-		Foods["herbstew"] = true;
-		Foods["meatandcheese"] = true;
-		Foods["meatandbread"] = true;
-		Foods["mushroomstew"] = true;
-		Foods["poorapplepie"] = true;
-		Foods["poorpate"] = true;
-		Foods["pickledmushrooms"] = true;
-		Foods["breadsoup"] = true;
-		Foods["shepardroast"] = true;
-		Foods["pooreggs"] = true;
-		Foods["beerfish"] = true;
-		Foods["spicypie"] = true;
-		Foods["vegepie"] = true;
-		Foods["fatstew"] = true;
-		Foods["bearstew"] = true;
-		Foods["hunterspecial"] = true;
-		Foods["speedstew"] = true;
-		Foods["smokedherbfish"] = true;
-		Foods["meatpacks"] = true;
-		Foods["herbmushroombrewing"] = true;
-		Foods["berryjam"] = true;
-		Foods["strengthjam"] = true;
-		Foods["dexdumplings"] = true;
-		Foods["simpleoysters"] = true;
-		Foods["berrycompote"] = true;
-		Foods["raspberrydrink"] = true;
-		Foods["grapejuice"] = true;
-		Foods["raspberrytincture"] = true;
-		Foods["exoticdessert"] = true;
-		Foods["applepie"] = true;
-		Foods["spicyfish"] = true;
-		Foods["herbfishsoup"] = true;
-		Foods["trollsoup"] = true;
-		Foods["weedstew"] = true;
-		Foods["fishpot"] = true;
-
-		Foods["batstew"] = false;
-		Foods["redstew"] = false;
-		Foods["bluestew"] = false;
-		Foods["slagermeat"] = false;
-		Foods["marthsoup"] = false;
-		Foods["marthsoup2"] = false;
-		Foods["marthsoup3"] = false; //nob_checkmeal_marthastew
-		Foods["marthsoup4"] = false; //nob_checkmeal_marthastew_str
 	}
 
 	void Game_Exit() {
@@ -242,7 +138,7 @@ namespace GOTHIC_ENGINE {
 	void Game_Loop() {
 		if (zKeyPressed(KEY_P) && !bInMenu) {
 			iMenuPage = 0;
-			iMenuPageMax = (static_cast<int>(Foods.size()) / iMenuItemsMax);
+			iMenuPageMax = (Dishes::GetAllDishesCount() / iMenuItemsMax);
 			OpenMenu();
 		}
 

--- a/zFoods_TCoM/Plugin.h
+++ b/zFoods_TCoM/Plugin.h
@@ -1,9 +1,6 @@
 // This file added in headers queue
 // File: "Headers.h"
 
-#include <map>
-#include <vector>
-
 namespace GOTHIC_ENGINE {
 #define FACTOR 81.919998
 #define F(a) static_cast<int>(a * FACTOR)
@@ -14,6 +11,4 @@ namespace GOTHIC_ENGINE {
 	int iMenuPage;
 	int iMenuPageMax;
 	int iMenuItemsMax = 25;
-
-	std::map<string, bool_t, std::less<string>> Foods;
 }

--- a/zFoods_TCoM/Sources.h
+++ b/zFoods_TCoM/Sources.h
@@ -4,6 +4,7 @@
 // Automatically generated block
 #pragma region Includes
 #include "Plugin.cpp"
+#include "Dishes.cpp"
 #pragma endregion
 
 // ...

--- a/zFoods_TCoM/ZenGin/Gothic_UserAPI/oCItem.inl
+++ b/zFoods_TCoM/ZenGin/Gothic_UserAPI/oCItem.inl
@@ -3,3 +3,4 @@
 // User API for oCItem
 // Add your methods here
 
+void RenderItem_Union(zCWorld*, zCViewBase*, float);

--- a/zFoods_TCoM/zFoods_TCoM.vcxproj.filters
+++ b/zFoods_TCoM/zFoods_TCoM.vcxproj.filters
@@ -2778,6 +2778,12 @@
       <Filter>Plugin\Workspace\Plugin</Filter>
     </ClInclude>
     <ClInclude Include="resource.h" />
+    <ClInclude Include="Dishes.h">
+      <Filter>Plugin\Workspace\Plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="Dishes.cpp">
+      <Filter>Plugin\Workspace\Plugin</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".build_settings.inl">


### PR DESCRIPTION
Created `static class` `Dishes` with `Data` (`std::map`) that represents all dishes in game and their variables responsible for check if dish was eaten and sell possibility and then if it was sold.
I decided to make it some kind of singleton to avoid `string` concatenations and other computations like `GetAllDishesCount()` and `GetAllGivableCount()` to be counted once because their size will not change.
I chosen speed over memory. I don't even know if it's needed in this kind of situation as plugin for Union.

Then I added info about *currently sold dishes count / sellable dishes count* and *currently eaten dishes count / all dishes count* above Jil and Eaten prints.
![Gothic2_pD8eT399ql](https://github.com/user-attachments/assets/e87c9dfd-b153-4c1a-829d-8a449e2b2164)

Finally I added letter sings in inventory grid that indicates that dish was never sold to Jil or was never eaten.
![obraz](https://github.com/user-attachments/assets/edfc1ef8-8596-4236-9579-df8fe04bf737)
**B** stands for bonus - so eat to get bonus
**J** stands for Jil - so sell to Jill is possible